### PR TITLE
feat: Add room title and editing functionality

### DIFF
--- a/src/models/listener.schema.ts
+++ b/src/models/listener.schema.ts
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 const ListenerSchema = new mongoose.Schema({
   pbKey: String,
   rid: String,
+  title: String,
   profanityEnabled: { type: Boolean, default: false },
   messages: [{ type: mongoose.Schema.Types.Mixed, default: [] }]
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -174,7 +174,7 @@
 	</div>
 
 	<footer class="
-	text-primary fixed bottom-0 flex w-full items-center 
+	text-primary fixed bottom-0 flex w-full items-center
 	bg-base-100 justify-center z-50">
 		<span class="p-1 text-sm font-extralight"
 			>A <a class="underline" href="https://robi.work">robi.work</a> site

--- a/src/routes/api/pgp/+server.ts
+++ b/src/routes/api/pgp/+server.ts
@@ -50,6 +50,7 @@ export async function POST({ request }) {
   const newListener = new Listener({
     pbKey,
     rid,
+    title: rid,
     messages: []
   });
 

--- a/src/routes/api/prof/+server.ts
+++ b/src/routes/api/prof/+server.ts
@@ -1,14 +1,9 @@
 import { json } from "@sveltejs/kit";
 import Listener from "../../../models/listener.schema";
 
-interface Listener {
-  pbKey: string;
-  rid: string;
-}
-
 export async function PATCH({ request }) {
   const body = await request.json();
-  const { pbKey, rid } = body;
+  const { pbKey } = body;
   const profanityEnabledStatus = body.profanityEnabled;
   console.log('PATCH /api/prof/:pbKey called with body:', body);
   try {
@@ -16,7 +11,7 @@ export async function PATCH({ request }) {
 
     if (profanityEnabledStatus === undefined) {
       // If profanityEnabled is not in the body, find the room and return its state
-      room = await Listener.findOne({ rid: rid }, { profanityEnabled: 1, _id: 0 });
+      room = await Listener.findOne({ pbKey: pbKey }, { profanityEnabled: 1, _id: 0 });
     } else {
       // If profanityEnabled is in the body, update the room with that state
       console.log("!!profanityEnabledStatus ", !!profanityEnabledStatus);

--- a/src/routes/api/prof/+server.ts
+++ b/src/routes/api/prof/+server.ts
@@ -3,7 +3,7 @@ import Listener from "../../../models/listener.schema";
 
 export async function PATCH({ request }) {
   const body = await request.json();
-  const { pbKey } = body;
+  const { rid, pbKey } = body;
   const profanityEnabledStatus = body.profanityEnabled;
   console.log('PATCH /api/prof/:pbKey called with body:', body);
   try {
@@ -11,7 +11,7 @@ export async function PATCH({ request }) {
 
     if (profanityEnabledStatus === undefined) {
       // If profanityEnabled is not in the body, find the room and return its state
-      room = await Listener.findOne({ pbKey: pbKey }, { profanityEnabled: 1, _id: 0 });
+      room = await Listener.findOne({ rid: rid }, { profanityEnabled: 1, _id: 0 });
     } else {
       // If profanityEnabled is in the body, update the room with that state
       console.log("!!profanityEnabledStatus ", !!profanityEnabledStatus);
@@ -19,7 +19,7 @@ export async function PATCH({ request }) {
       room = await Listener.findOneAndUpdate(
         { pbKey: pbKey },
         { $set: { profanityEnabled: !!profanityEnabledStatus } },
-        { new: true, fields: { profanityEnabled: 1, _id: 0 }}
+        { new: true, fields: { profanityEnabled: 1, _id: 0 } }
       );
 
       console.log('Updated room:', room);

--- a/src/routes/api/titl/+server.ts
+++ b/src/routes/api/titl/+server.ts
@@ -1,0 +1,50 @@
+import { json } from "@sveltejs/kit";
+import Listener from "../../../models/listener.schema";
+
+interface Listener {
+	pbKey: string;
+	rid: string;
+	title: string;
+}
+
+export async function GET(request) {
+	const rid = request.url.searchParams.get('rid');
+
+	try {
+		const room = await Listener.findOne(
+			{ rid: rid },
+			{ title: 1, _id: 0 }
+		);
+
+		if (room) {
+			return json({ status: 200, body: room });
+		} else {
+			return json({ status: 404, body: 'Room not found' });
+		}
+	} catch (error) {
+		console.error('GET error:', error);
+		return json({ status: 500, body: 'Error fetching room title' });
+	}
+}
+
+export async function PATCH({ request }) {
+	const body = await request.json();
+	const { pbKey, title } = body as Listener;
+	try {
+		const room = await Listener.findOneAndUpdate(
+			{ pbKey: pbKey },
+			{ $set: { title: title } },
+			{ new: true, fields: { title: 1, _id: 0 } }
+		);
+
+
+		if (room) {
+			return json({ status: 200, body: room });
+		} else {
+			return json({ status: 404, body: 'Room not found' });
+		}
+	} catch (error) {
+		console.error('PATCH error:', error);
+		return json({ status: 500, body: 'Error updating room' });
+	}
+}

--- a/src/routes/api/titl/+server.ts
+++ b/src/routes/api/titl/+server.ts
@@ -9,11 +9,11 @@ interface Listener {
 
 export async function GET(request) {
 	const rid = request.url.searchParams.get('rid');
-
+	console.log('GET /api/title/:rid called with rid:', rid, typeof rid);
 	try {
 		const room = await Listener.findOne(
 			{ rid: rid },
-			{ title: 1, _id: 0 }
+			{ title: 1, rid: 1}
 		);
 
 		if (room) {
@@ -36,8 +36,6 @@ export async function PATCH({ request }) {
 			{ $set: { title: title } },
 			{ new: true, fields: { title: 1, _id: 0 } }
 		);
-
-
 		if (room) {
 			return json({ status: 200, body: room });
 		} else {

--- a/src/routes/b/[room]/+page.svelte
+++ b/src/routes/b/[room]/+page.svelte
@@ -37,6 +37,7 @@
 	let cleartextMessage = '';
 	let sent = false;
 	let profanityWarning = false;
+	let roomTitle = '';
 
 	$: postable = !!message;
 
@@ -181,6 +182,8 @@
 			console.log('Fetching public key');
 			await fetchKeys();
 		}
+		await fetchRoomTitle();
+
 		// Check if the user has a PGP identity
 		if (!prKey || !pbKey || !RC || !uniqueString) {
 			({ prKey, pbKey, RC, uniqueString } = await GetPgpIdentity());
@@ -190,6 +193,23 @@
 			ResetPgpIdentity();
 		}
 	});
+
+	async function fetchRoomTitle() {
+		const responseTitle = await fetch(`/api/titl?rid=${params}`, {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		});
+
+		const respTitle = await responseTitle.json();
+
+		if (respTitle.error) {
+			console.log(respTitle.message);
+		} else {
+			roomTitle = respTitle.body.title;
+		}
+	}
 
 	let powerUser = false;
 </script>
@@ -202,7 +222,7 @@
 			class=" relative w-full bg-base-200 p-4 text-left text-xl font-semibold text-primary transition-all md:text-2xl lg:text-4xl"
 		>
 			Send to <span class="rounded-sm bg-base-300 p-1 font-extralight text-primary">
-				{params}
+				{roomTitle}
 			</span>
 		</h1>
 	</div>

--- a/src/routes/li/[room]/+page.svelte
+++ b/src/routes/li/[room]/+page.svelte
@@ -9,6 +9,7 @@
 	import Message from '$lib/_components/Message.svelte';
 	import PencilSimpleLine from 'phosphor-svelte/lib/PencilSimpleLine';
 	import FloppyDisk from 'phosphor-svelte/lib/FloppyDisk';
+	import X from 'phosphor-svelte/lib/X';
 
 	let rid = $page.params.room;
 	let unlocked = false;
@@ -255,34 +256,45 @@
 >
 	<div class="flex w-full flex-row gap-2 p-1 pb-1">
 		<h1
-			class=" relative w-full bg-base-200 p-4 text-left text-xl
-		font-semibold text-primary/90 md:text-3xl lg:text-4xl"
+			class=" relative flex w-full flex-row items-center justify-start
+		gap-2 bg-base-200 p-4 text-left text-xl font-semibold text-primary/90 md:text-3xl lg:text-4xl"
 		>
 			Room
 			{#if isEditingTitle}
 				<input
 					bind:value={roomTitle}
 					type="text"
-					class="rounded-sm border-none bg-base-300 p-1 font-extralight text-base-content"
+					class="min-h-8 rounded-sm border-none bg-base-300 p-1 font-extralight text-base-content focus:bg-base-100 focus:outline-none"
 					size={roomTitle.length > 5 ? roomTitle.length : 5}
 					style={`font-size: ${Math.ceil(roomTitle.length / 50)}em`}
 				/>
 				<button
 					on:click={() => {
+						if (roomTitle.length <= 0) return;
 						updateRoomTitle();
 						toggleEditTitle();
 					}}
-					class="btn btn-sm my-4"><FloppyDisk size="24" weight="duotone" /></button
+					class="btn btn-square btn-sm"
 				>
+					<FloppyDisk size="24" weight="duotone" />
+				</button>
+				<button
+					on:click={() => {
+						toggleEditTitle();
+					}}
+					class="btn btn-square btn-sm"
+				>
+					<X size="24" weight="duotone" />
+				</button>
 			{:else}
 				<span
 					class="pointer-events-none rounded-sm border-none bg-base-300 p-1 font-extralight text-base-content"
 				>
 					{roomTitle}
 				</span>
-				<button on:click={toggleEditTitle} class="btn btn-sm my-4"
-					><PencilSimpleLine size="24" weight="duotone" /></button
-				>
+				<button on:click={toggleEditTitle} class="btn btn-sm my-4">
+					<PencilSimpleLine size="24" weight="duotone" />
+				</button>
 			{/if}
 			{#if unlocked}
 				<span

--- a/src/routes/li/[room]/+page.svelte
+++ b/src/routes/li/[room]/+page.svelte
@@ -167,7 +167,7 @@
 			headers: {
 				'Content-Type': 'application/json'
 			},
-			body: JSON.stringify({ pbKey: pbKey })
+			body: JSON.stringify({ rid: rid })
 		});
 
 		const resp = await response.json();

--- a/src/routes/li/[room]/+page.svelte
+++ b/src/routes/li/[room]/+page.svelte
@@ -17,7 +17,7 @@
 	let prKey: string;
 	let pbKey: string;
 	let profanityFilterEnabled = false;
-	let roomTitle = '';
+	let roomTitle = rid;
 	let isEditingTitle = false;
 
 	let encryptedMessages: any[] = [];
@@ -145,6 +145,7 @@
 			intervalId = setInterval(unpack, pollingInterval * 1000);
 		}
 	}
+
 	onMount(async () => {
 		// Check if the user has a PGP identity
 		if (rid) {
@@ -152,6 +153,7 @@
 		}
 		// add a constant loop that calls unpack
 		unpack();
+
 		if (unlocked) {
 			if (intervalId) clearInterval(intervalId);
 			intervalId = setInterval(unpack, pollingInterval * 1000);
@@ -205,26 +207,23 @@
 			console.log(respUpdateTitle.message);
 		} else {
 			roomTitle = respUpdateTitle.body.title;
-			console.log(`Title changed to "${respUpdateTitle.body.title}"`);
 		}
 	}
 
 	async function fetchRoomTitle() {
-
 		const responseTitle = await fetch(`/api/titl?rid=${rid}`, {
 			method: 'GET',
 			headers: {
 				'Content-Type': 'application/json'
 			}
 		});
-
 		const respTitle = await responseTitle.json();
-
+		console.log('resp', respTitle);
 
 		if (respTitle.error) {
 			console.log(respTitle.message);
 		} else {
-			roomTitle = respTitle.body.title;
+			roomTitle = respTitle.body.title.length == 0 ? respTitle.body.rid : respTitle.body.title;
 		}
 	}
 
@@ -241,7 +240,6 @@
 		});
 
 		const resp = await response.json();
-
 
 		if (resp.error) {
 			console.log(resp.message);
@@ -265,16 +263,26 @@
 				<input
 					bind:value={roomTitle}
 					type="text"
-					class="rounded-sm bg-base-300 p-1 font-extralight text-base-content border-none"
+					class="rounded-sm border-none bg-base-300 p-1 font-extralight text-base-content"
 					size={roomTitle.length > 5 ? roomTitle.length : 5}
 					style={`font-size: ${Math.ceil(roomTitle.length / 50)}em`}
+				/>
+				<button
+					on:click={() => {
+						updateRoomTitle();
+						toggleEditTitle();
+					}}
+					class="btn btn-sm my-4"><FloppyDisk size="24" weight="duotone" /></button
 				>
-				<button on:click={() => {updateRoomTitle(); toggleEditTitle();}} class="btn btn-sm my-4"><FloppyDisk size="24" weight="duotone"/></button>
 			{:else}
-  <span class="pointer-events-none rounded-sm bg-base-300 p-1 font-extralight text-base-content border-none">
-    {roomTitle}
-  </span>
-				<button on:click={toggleEditTitle} class="btn btn-sm my-4"><PencilSimpleLine size="24" weight="duotone"/></button>
+				<span
+					class="pointer-events-none rounded-sm border-none bg-base-300 p-1 font-extralight text-base-content"
+				>
+					{roomTitle}
+				</span>
+				<button on:click={toggleEditTitle} class="btn btn-sm my-4"
+					><PencilSimpleLine size="24" weight="duotone" /></button
+				>
 			{/if}
 			{#if unlocked}
 				<span

--- a/src/routes/li/[room]/+page.svelte
+++ b/src/routes/li/[room]/+page.svelte
@@ -264,6 +264,15 @@
 				<input
 					bind:value={roomTitle}
 					type="text"
+					minlength="1"
+					maxlength="24"
+					on:keydown={(e) => {
+						if (e.key === 'Enter') {
+							if (roomTitle.length <= 0) return;
+							updateRoomTitle();
+							toggleEditTitle();
+						}
+					}}
 					class="min-h-8 rounded-sm border-none bg-base-300 p-1 font-extralight text-base-content focus:bg-base-100 focus:outline-none"
 					size={roomTitle.length > 5 ? roomTitle.length : 5}
 					style={`font-size: ${Math.ceil(roomTitle.length / 50)}em`}


### PR DESCRIPTION
In this pull request, I have added the feature to fetch and edit the title of a room in our application. Here's a brief summary of the changes:

- **Editing Room Title:** Users can now edit the title of the room from the frontend. The new title is sent to the backend and updated in the database.

## 🔄 Changes to Existing Code:

- Updated the room component to include the new title input field and its functionality.
- Added a new endpoint in the API to handle updating the room title.
- Updated the room schema in the database to include the title.

## 🔮 Future Plans:

- **Encrypting Title:** In future iterations, planed to enhance security by encrypting the room title before storing it in the database.

also fixed the issue [#13)