### PR TITLE
feat: Slowmode to send message to a room

### DIFF
--- a/src/models/room.schema.ts
+++ b/src/models/room.schema.ts
@@ -4,6 +4,7 @@ const RoomSchema = new mongoose.Schema({
   pbKey: String,
   rid: String,
   profanityEnabled: { type: Boolean, default: false },
+  slowMode: { type: Number, default: 0 }, // slow mode delay in seconds
   messages: [
     {
       type: mongoose.Schema.Types.ObjectId,


### PR DESCRIPTION
Related to #5

Add slow mode setting to rooms to disable API queries based on delay.

* **Room Schema**: Add `slowMode` field to `RoomSchema` in `src/models/room.schema.ts` to store the slow mode delay.
* **API Server**: Update `src/routes/api/pgp/+server.ts` to check the `slowMode` setting and disable API queries if the delay has not passed.
* **UI for Slow Mode**: Modify `src/routes/b/[room]/+page.svelte` to include a UI for setting the slow mode delay for a room.
* **Message Sending Logic**: Add logic to `src/routes/b/[room]/+page.svelte` to respect the slow mode delay when sending messages.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/RobiMez/sma/issues/5?shareId=09cf7ed6-e4ff-4629-aecd-bcae6c3f5b64).