### PR TITLE
feat(ui): add word redaction for received messages

### DIFF
--- a/src/routes/li/[room]/Message/Message.svelte
+++ b/src/routes/li/[room]/Message/Message.svelte
@@ -4,12 +4,14 @@
   import BlurhashThumbnail from './BlurhashThumbnail.svelte';
   import { domToPng } from 'modern-screenshot';
   import FileArrowDown from 'phosphor-svelte/lib/FileArrowDown';
+  import Eraser from 'phosphor-svelte/lib/Eraser';
   import Copy from 'phosphor-svelte/lib/Copy';
   import Check from 'phosphor-svelte/lib/Check';
   import XCircle from 'phosphor-svelte/lib/XCircle';
   import * as Dialog from '$lib/components/ui/dialog/index.js';
   import { Button } from '$lib/components/ui/button';
   import IdentityChip from '$lib/components/IdentityChip.svelte';
+  import MessageText from './MessageText.svelte';
   interface Props {
     msg: any;
   }
@@ -20,6 +22,22 @@
   let now = $state(new Date());
   let dialogOpen = $state(false);
   let copyState = $state<'idle' | 'copied' | 'error'>('idle');
+  let redactMode = $state(false);
+  let redactedIndices = $state(new Set<number>());
+
+  const toggleRedactMode = () => {
+    redactMode = !redactMode;
+  };
+
+  const toggleWordRedaction = (index: number) => {
+    const next = new Set(redactedIndices);
+    if (next.has(index)) {
+      next.delete(index);
+    } else {
+      next.add(index);
+    }
+    redactedIndices = next;
+  };
 
   const timestamp = $derived(new Date(msg.timestamp ?? 0));
   const time = $derived.by(() => {
@@ -126,9 +144,13 @@
       </span>
     {/if}
 
-    <span class="w-full min-w-0 break-words">
-      {msg.msg}
-    </span>
+    <MessageText
+      text={msg.msg}
+      {redactMode}
+      showHighlights={redactMode}
+      {redactedIndices}
+      onWordClick={toggleWordRedaction}
+    />
     <div class="absolute right-2 bottom-2 flex flex-row items-center justify-center">
       <button
         class="text-xs hover:opacity-70 transition-opacity cursor-pointer"
@@ -138,14 +160,27 @@
         {time}
       </button>
     </div>
-    <button
-      class="border-primary bg-background absolute -top-5 right-4 flex h-7 w-7 items-center justify-center border text-sm opacity-0 transition-all group-hover:opacity-100"
-      onclick={() => {
-        dialogOpen = !dialogOpen;
-      }}
+    <span
+      class="absolute -top-5 right-4 flex flex-row gap-1 opacity-0 transition-all group-hover:opacity-100"
     >
-      <FileArrowDown size={20} />
-    </button>
+      <button
+        class="border-primary flex h-7 w-7 items-center justify-center border text-sm transition-all
+          {redactMode ? 'bg-primary text-primary-foreground' : 'bg-background'}"
+        onclick={toggleRedactMode}
+        title={redactMode ? 'Exit redact mode' : 'Redact words'}
+      >
+        <Eraser size={20} />
+      </button>
+      <button
+        class="border-primary bg-background flex h-7 w-7 items-center justify-center border text-sm"
+        onclick={() => {
+          dialogOpen = !dialogOpen;
+        }}
+        title="Save image"
+      >
+        <FileArrowDown size={20} />
+      </button>
+    </span>
   </div>
 </div>
 
@@ -177,9 +212,7 @@
             </span>
           {/if}
 
-          <span class="w-full min-w-0 text-left break-words">
-            {msg.msg}
-          </span>
+          <MessageText text={msg.msg} {redactedIndices} />
           <div class="absolute right-2 bottom-2 flex flex-row items-center justify-center">
             <button
               class="text-xs hover:opacity-70 transition-opacity cursor-pointer"

--- a/src/routes/li/[room]/Message/MessageText.svelte
+++ b/src/routes/li/[room]/Message/MessageText.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  interface Token {
+    type: 'word' | 'space';
+    value: string;
+    index?: number;
+    key: string;
+  }
+
+  interface Props {
+    text: string;
+    redactMode?: boolean;
+    showHighlights?: boolean;
+    redactedIndices: Set<number>;
+    onWordClick?: (index: number) => void;
+  }
+
+  let {
+    text,
+    redactMode = false,
+    showHighlights = false,
+    redactedIndices,
+    onWordClick
+  }: Props = $props();
+
+  function parseTokens(message: string): Token[] {
+    const result: Token[] = [];
+    const regex = /(\S+)|(\s+)/g;
+    let wordIndex = 0;
+    let tokenIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(message)) !== null) {
+      if (match[1]) {
+        result.push({
+          type: 'word',
+          value: match[1],
+          index: wordIndex++,
+          key: `word-${tokenIndex++}`
+        });
+      } else if (match[2]) {
+        result.push({
+          type: 'space',
+          value: match[2],
+          key: `space-${tokenIndex++}`
+        });
+      }
+    }
+
+    return result;
+  }
+
+  const tokens = $derived(parseTokens(text));
+</script>
+
+<span class="w-full min-w-0 break-words text-left">
+  {#each tokens as token (token.key)}
+    {#if token.type === 'space'}
+      {token.value}
+    {:else}
+      {@const index = token.index!}
+      {@const isRedacted = redactedIndices.has(index)}
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <span
+        class="inline transition-all duration-150
+          {isRedacted
+          ? 'rounded-[3px] bg-black px-[3px] text-black shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)] select-none'
+          : showHighlights && redactMode
+            ? 'cursor-pointer rounded-[3px] bg-yellow-300/45 ring-1 ring-yellow-500/30 hover:bg-yellow-400/55 dark:bg-yellow-500/25 dark:ring-yellow-400/20 dark:hover:bg-yellow-500/40'
+            : ''}"
+        onclick={() => {
+          if (redactMode && onWordClick) onWordClick(index);
+        }}
+      >
+        {token.value}
+      </span>
+    {/if}
+  {/each}
+</span>


### PR DESCRIPTION
Redaction is client-side only — it affects the on-screen view and exported images, not the stored message in the database.

<p align="center">
  <img
    src="https://github.com/user-attachments/assets/b3e24ac7-ed4d-4451-b249-792bd2e40eb5"
    alt="Login page"
    width="700"
  />
</p>

<p align="center">
  <img
    src="https://github.com/user-attachments/assets/fc6dd301-fddc-46c0-a340-4a03c6f8ed01"
    alt="Dashboard page"
    width="700"
  />
</p>