### PR TITLE
fix(li): unblank the inbox for ~2.7% of rooms, fix the mobile header, restore Sentry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,12 @@ PUBLIC_PGP_PASSPHRASE=
 # Backend base URL for API + WebSocket. Empty = same-origin (the box and local
 # dev). Set to https://s.sma.et on the Vercel frontend so it hits the box.
 PUBLIC_API_BASE=
+# Sentry ingest key (robi-codes/sma). A DSN is a public write-only key and is
+# meant to ship in the client bundle. Leave it empty and the SDK never
+# initialises — which is what you want locally, so dev noise doesn't land in
+# the project. Errors are scrubbed before send and Session Replay is off on
+# purpose; see src/lib/sentry.ts before changing either.
+PUBLIC_SENTRY_DSN=
+# Only needed by whatever builds for production: lets the Vite plugin upload
+# source maps so traces de-minify. Builds fine without it.
+SENTRY_AUTH_TOKEN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,8 @@ An "identity" is a curve25519 PGP keypair generated in the browser (`src/lib/uti
 
 On identity creation, only `{ pbKey, rid }` is POSTed to `/api/pgp`, which creates a `Listener` document. `getAllFromLS()` auto-generates a genesis identity if none exists, so first page load silently registers a listener.
 
+**`createShortHash` has exactly one implementation and must keep having one.** An rid is a name that gets minted once (`utils/pgp.ts`) and re-derived much later to unlock the inbox (`/li/[room]`); if the two derivations disagree by even one character, that identity is locked out of its own room forever, and there is no error anywhere to say so — `CheckIfUnlockable()` simply returns false and the page renders its header above an empty void. This has already happened once: `/li/[room]/+page.svelte` carried a copy-pasted second copy that had drifted to `.replace('+', '-')` with a **string** pattern, which replaces only the first match, so any hash containing two or more `+`/`/` was re-derived wrong. That is ~2.7% of all identities — including the reported `9WKgh__MaN6t`, which came back as `9WKgh_/MaN6t`. Import the helper from `$lib/utils/hashing`; don't reimplement it, and note that `src/lib/utils/hashing.test.ts` pins the output against fixtures rather than round-tripping, because a round-trip passes happily while both sides are wrong together.
+
 ### Message flow
 
 - `/b/[room]` — public send page (the shareable link). Fetches the recipient's public key by `rid`, encrypts the message to **both that key and the sender's own** (see "Editing sent messages" below), and **signs with the sender's private key**, then PATCHes `/api/pgp` with `{ message, imageData, audioData, r: senderRid, p: recipientRid }`. Below the composer it also lists what this identity has already sent to this room, with an inline editor and any replies the room owner wrote back.
@@ -122,6 +124,17 @@ The same machinery covers "prove you're this sender", not just "prove you own th
 When adding a new owner-only endpoint, gate it with `verifySignedAction` and call it from the client with `signedFetch` — do not trust a plain rid. Public reads (title, profanity flag for senders) stay unsigned GETs. User-supplied webhook URLs must pass `isSafeWebhookUrl` (`src/lib/server/webhookGuard.ts`) both on save and again at fire time (SSRF guard). Unit tests for the auth and SSRF logic live in `src/lib/server/*.test.ts`.
 
 `POST /api/pgp` (listener registration) rejects duplicate rids (409) and validates the armored `pbKey`; `rid` is a unique index on the `Listener` schema. The message-send `PATCH /api/pgp` type-checks and size-caps all fields so unvalidated objects can't reach Mongoose queries (NoSQL injection).
+
+### Error reporting (Sentry), and what it is not allowed to see
+
+`@sentry/sveltekit`, initialised in both `hooks.client.ts` and `hooks.server.ts`, gated on `PUBLIC_SENTRY_DSN` — no DSN, no SDK, which is the default locally and in CI so dev noise stays out of the project. The DSN is a public write-only ingest key and is meant to ship in the client bundle; `SENTRY_AUTH_TOKEN` is separate and only enables source-map upload, which is also what gates the Vite plugin (see `vite.config.ts` — the plugin does nothing useful without a token and drags Babel into the module graph, burying every build in circular-dependency warnings).
+
+Error reporting sits awkwardly on an app whose entire premise is that plaintext never leaves the browser, so two rules in `src/lib/sentry.ts` are load-bearing:
+
+- **Session Replay is never enabled, and DOM breadcrumbs are off.** Replay records the DOM, and by the time a message is on screen in `/li/[room]` it has already been decrypted — turning it on would hand Sentry exactly the plaintext the server is designed never to receive. DOM breadcrumbs describe the element a user clicked, which on that page means from inside a message bubble.
+- **Everything else goes through `scrubEvent` first** (`beforeSend` + `beforeSendTransaction`). It strips armored PGP blocks — openpgp.js quotes its input, so a failed `decrypt` can carry ciphertext or a private key into the exception text — and replaces room ids in paths and query strings, since an rid is the name of a room and a URL rides along with every event. Route *patterns* (`/li/[room]`) are deliberately kept: they name nobody and are what makes grouping useful. The scrub is a blanket walk over every string in the event rather than a list of known fields, because the SDK invents new places to put strings faster than an allowlist keeps up and the failure mode is leaking plaintext.
+
+Note what Sentry does **not** buy you here: the unlock bug above threw nothing. It returned `false` and rendered an empty page, so no error reporter would ever have seen it. Silent-wrong-answer bugs need tests or an explicit failure state in the UI, not instrumentation.
 
 ### Two deploy targets + WebSocket live updates
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@lucide/svelte": "^0.515.0",
     "@openpgp/web-stream-tools": "0.0.11-patch-0",
     "@playwright/test": "^1.61.0",
+    "@sentry/sveltekit": "^10.70.0",
     "@sveltejs/adapter-auto": "^3.3.1",
     "@sveltejs/adapter-node": "^5.5.7",
     "@sveltejs/adapter-vercel": "^6.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,18 +73,21 @@ importers:
       '@playwright/test':
         specifier: ^1.61.0
         version: 1.61.0
+      '@sentry/sveltekit':
+        specifier: ^10.70.0
+        version: 10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(rollup@4.62.0)(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
       '@sveltejs/adapter-auto':
         specifier: ^3.3.1
-        version: 3.3.1(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))
+        version: 3.3.1(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))
       '@sveltejs/adapter-node':
         specifier: ^5.5.7
-        version: 5.5.7(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))
+        version: 5.5.7(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))
       '@sveltejs/adapter-vercel':
         specifier: ^6.3.4
-        version: 6.3.4(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(rollup@4.62.0)
+        version: 6.3.4(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(rollup@4.62.0)
       '@sveltejs/kit':
         specifier: ^2.70.2
-        version: 2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
         version: 6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -102,7 +105,7 @@ importers:
         version: 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       bits-ui:
         specifier: ^2.18.1
-        version: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)
+        version: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -153,13 +156,91 @@ importers:
         version: 7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@24.3.0)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
+    resolution: {integrity: sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    resolution: {integrity: sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -412,6 +493,48 @@ packages:
   '@openpgp/web-stream-tools@0.0.11-patch-0':
     resolution: {integrity: sha512-NrIF4DkCqC3WDcMDAgz17z+0Iik1fVrKuvdbjZXCnMZgYAWHpIG8CWnbp8yQRahAdF26jqCopA/qXrp8CYI2yw==}
 
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
+
   '@playwright/test@1.61.0':
     resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
     engines: {node: '>=18'}
@@ -602,6 +725,167 @@ packages:
     resolution: {integrity: sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==}
     cpu: [x64]
     os: [win32]
+
+  '@sentry/browser-utils@10.70.0':
+    resolution: {integrity: sha512-IvjhafF5NFXrPCg5EHbAPGDwIhHxgUcLlHTklZ3DAdA6ky88BJYMfevbcnOEmgavf4nylhCaquRUFNB5+szj+A==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.70.0':
+    resolution: {integrity: sha512-IK6+J+8H06tZe+A8L37TT5ZxxwNtyQatW8zl5RYYJ/e9CsjrM8fPi8I1OT7uquTw8UtjqFHt7bEef/Vy63ksPg==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugins@10.70.0':
+    resolution: {integrity: sha512-M+a32VOZVeTUxF+QecQ+OHYj8hb5FeppKwwWpTQ9cfS6ixgoNUK7/B7NhB2XbfxE3F1BcGvOxyS+AB+fvPfSRQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      webpack:
+        optional: true
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/cloudflare@10.70.0':
+    resolution: {integrity: sha512-jlr9txw3lQrbc6KQn9FzlpgC1KcB36u7aIGSlUhXAZ2MB93DgwjuTnHF20qQHxmHbZylg7CtHoMq3rGiTXAgpg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.x || ^5.x
+      wrangler: ^4.x
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      wrangler:
+        optional: true
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.70.0':
+    resolution: {integrity: sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.70.0':
+    resolution: {integrity: sha512-6VQn2ETJjHkk4QQDdx/587/JDfXsk3yBTLZ3UZOMtBVrkmwgk+1FJZ8ULJ3ud1xZcuh2icunIkc7tGVv2axdnw==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.70.0':
+    resolution: {integrity: sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.70.0':
+    resolution: {integrity: sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.70.0':
+    resolution: {integrity: sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/replay-canvas@10.70.0':
+    resolution: {integrity: sha512-irzpw22bK5CF3jbecDa0gBUcfjv7tgeUoLAvtIfeHOP5ajmf3o4Cp99a9RQqkfgvkcMeRZBUwE91SQhp6Ank+w==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.70.0':
+    resolution: {integrity: sha512-xMnSGzJn9Xd29rYd32lkx/gFW+5mtgqADJ2FiZvis0MBGZuDlNRwPn0/Cs1xA3JNXKV3NGfhdmmvs90w4dHSmw==}
+    engines: {node: '>=18'}
+
+  '@sentry/server-utils@10.70.0':
+    resolution: {integrity: sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==}
+    engines: {node: '>=18'}
+
+  '@sentry/svelte@10.70.0':
+    resolution: {integrity: sha512-AX7Xm15oHD3oVgw1Rx0zohYy5XEsrbjFdDIvkqPs3p3lEeLTMOyXO9PEBKw+c4yhfJADS8QDU1Y1wuZAonGSkw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      svelte: 3.x || 4.x || 5.x
+
+  '@sentry/sveltekit@10.70.0':
+    resolution: {integrity: sha512-UF9a/UniSOoBzmUby0bfvzoBjP496M1m6n5vvdXB+HKcQv/NtOxaPl1dV8OsFYkpJzREQ+uEX5493rHIxK9tUw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@sveltejs/kit': 2.x || ^3.0.0-0
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  '@sentry/vite-plugin@5.4.0':
+    resolution: {integrity: sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==}
+    engines: {node: '>= 18'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -910,6 +1194,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -943,6 +1231,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
 
@@ -956,6 +1248,11 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  baseline-browser-mapping@2.11.15:
+    resolution: {integrity: sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -984,6 +1281,11 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   bson@6.10.4:
     resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
     engines: {node: '>=16.20.1'}
@@ -991,6 +1293,9 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1007,6 +1312,9 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  cjs-module-lexer@2.2.1:
+    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -1084,6 +1392,13 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
+  electron-to-chromium@1.5.408:
+    resolution: {integrity: sha512-SLoprcYpJ/OH2v2ps0+N5biv9H4/KBT3+YmmDew64TwK5y9j2wv7pMOFY7IorVkyMtEyLSCRlXKLsNlakeAlPw==}
+
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
@@ -1095,10 +1410,17 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1252,6 +1574,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1272,9 +1598,15 @@ packages:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
 
+  globalyzer@0.1.0:
+    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
+
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1289,6 +1621,10 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1306,6 +1642,10 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
+    engines: {node: '>=18'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -1360,8 +1700,16 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1372,6 +1720,11 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   kareem@2.6.3:
     resolution: {integrity: sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==}
@@ -1483,6 +1836,9 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1496,6 +1852,10 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1511,6 +1871,9 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1521,6 +1884,9 @@ packages:
 
   modern-screenshot@4.7.0:
     resolution: {integrity: sha512-9YxN+ddPSMMlhylOv25VHzXrl9u67QRxoh7+SEewGtgUw7t6hHTrjptSDJUSne9oG4Xk/h2cwG15nIt4Hc9ujg==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mongodb-connection-string-url@3.0.2:
     resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
@@ -1598,6 +1964,10 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
 
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
@@ -1800,6 +2170,13 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1810,6 +2187,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1857,6 +2238,13 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.8.4:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
@@ -1887,8 +2275,16 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  sorcery@1.0.0:
+    resolution: {integrity: sha512-5ay9oJE+7sNmhzl3YNG18jEEEf4AOQCM/FAqR5wMmzqd1FtRorFbJXn3w3SKOhbiQaVgHM+Q1lszZspjri7bpA==}
+    hasBin: true
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   sparse-bitfield@3.0.3:
@@ -1978,6 +2374,9 @@ packages:
   theme-change@2.5.2:
     resolution: {integrity: sha512-UOLweDXAKIKDio6XVElNSlhDCRM8XtOk3rih/NImOldhiOkjZqrAmmEBjiWBVipfXt0WOETVNY7ym4W+UwjcxQ==}
 
+  tiny-glob@0.2.9:
+    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2038,6 +2437,12 @@ packages:
 
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -2188,6 +2593,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -2206,6 +2614,130 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      es-module-lexer: 2.1.0
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.8
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -2398,6 +2930,49 @@ snapshots:
       '@mattiasbuelens/web-streams-adapter': 0.1.0
       web-streams-polyfill: 3.0.3
 
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.3
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
+
   '@playwright/test@1.61.0':
     dependencies:
       playwright: 1.61.0
@@ -2522,29 +3097,219 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.0':
     optional: true
 
+  '@sentry/browser-utils@10.70.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+
+  '@sentry/browser@10.70.0':
+    dependencies:
+      '@sentry/browser-utils': 10.70.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      '@sentry/feedback': 10.70.0
+      '@sentry/replay': 10.70.0
+      '@sentry/replay-canvas': 10.70.0
+
+  '@sentry/bundler-plugins@10.70.0(rollup@4.62.0)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/cli': 2.58.6
+      '@sentry/core': 10.70.0
+      dotenv: 17.4.2
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.62.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cloudflare@10.70.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@sentry/core': 10.70.0
+      '@sentry/server-utils': 10.70.0
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.70.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
+  '@sentry/feedback@10.70.0':
+    dependencies:
+      '@sentry/core': 10.70.0
+
+  '@sentry/node-core@10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      '@sentry/opentelemetry': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.3.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      '@sentry/node-core': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.70.0
+      import-in-the-middle: 3.3.3
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+
+  '@sentry/replay-canvas@10.70.0':
+    dependencies:
+      '@sentry/core': 10.70.0
+      '@sentry/replay': 10.70.0
+
+  '@sentry/replay@10.70.0':
+    dependencies:
+      '@sentry/browser-utils': 10.70.0
+      '@sentry/core': 10.70.0
+
+  '@sentry/server-utils@10.70.0':
+    dependencies:
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.4
+      '@apm-js-collab/tracing-hooks': 0.13.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      meriyah: 6.1.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/svelte@10.70.0(svelte@5.56.3)':
+    dependencies:
+      '@sentry/browser': 10.70.0
+      '@sentry/core': 10.70.0
+      magic-string: 0.30.21
+      svelte: 5.56.3
+
+  '@sentry/sveltekit@10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(rollup@4.62.0)(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@sentry/cloudflare': 10.70.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      '@sentry/node': 10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/svelte': 10.70.0(svelte@5.56.3)
+      '@sentry/vite-plugin': 5.4.0(rollup@4.62.0)
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
+      '@sveltejs/kit': 2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
+      acorn: 8.17.0
+      magic-string: 0.30.21
+      sorcery: 1.0.0
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - encoding
+      - rollup
+      - supports-color
+      - svelte
+      - webpack
+      - wrangler
+
+  '@sentry/vite-plugin@5.4.0(rollup@4.62.0)':
+    dependencies:
+      '@sentry/bundler-plugins': 10.70.0(rollup@4.62.0)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+      - webpack
+
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.17.0)':
     dependencies:
       acorn: 8.17.0
 
-  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))':
+  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))':
     dependencies:
-      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
       import-meta-resolve: 4.2.0
 
-  '@sveltejs/adapter-node@5.5.7(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))':
+  '@sveltejs/adapter-node@5.5.7(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.3(rollup@4.62.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.62.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.0)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.0)
-      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
       rollup: 4.62.0
 
-  '@sveltejs/adapter-vercel@6.3.4(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(rollup@4.62.0)':
+  '@sveltejs/adapter-vercel@6.3.4(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(rollup@4.62.0)':
     dependencies:
-      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
       '@vercel/nft': 1.10.2(rollup@4.62.0)
       esbuild: 0.28.1
     transitivePeerDependencies:
@@ -2552,7 +3317,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
@@ -2570,6 +3335,7 @@ snapshots:
       svelte: 5.56.3
       vite: 7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       typescript: 5.9.3
 
   '@sveltejs/load-config@0.1.1': {}
@@ -2857,6 +3623,12 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv@6.15.0:
@@ -2887,6 +3659,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  astring@1.9.0: {}
+
   async-sema@3.1.1: {}
 
   axobject-query@4.1.0: {}
@@ -2895,19 +3669,21 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  baseline-browser-mapping@2.11.15: {}
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
 
-  bits-ui@2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3):
+  bits-ui@2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3):
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/dom': 1.7.6
       '@internationalized/date': 3.12.2
       esm-env: 1.2.2
-      runed: 0.35.1(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)
+      runed: 0.35.1(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)
       svelte: 5.56.3
-      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)
+      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)
       tabbable: 6.4.0
     transitivePeerDependencies:
       - '@sveltejs/kit'
@@ -2929,9 +3705,19 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.28.8:
+    dependencies:
+      baseline-browser-mapping: 2.11.15
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.408
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
   bson@6.10.4: {}
 
   callsites@3.1.0: {}
+
+  caniuse-lite@1.0.30001809: {}
 
   chai@6.2.2: {}
 
@@ -2945,6 +3731,8 @@ snapshots:
       readdirp: 4.1.2
 
   chownr@3.0.0: {}
+
+  cjs-module-lexer@2.2.1: {}
 
   clsx@2.1.1: {}
 
@@ -2996,6 +3784,10 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  dotenv@17.4.2: {}
+
+  electron-to-chromium@1.5.408: {}
+
   enhanced-resolve@5.21.6:
     dependencies:
       graceful-fs: 4.2.11
@@ -3004,6 +3796,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-module-lexer@2.3.2: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -3033,6 +3827,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3208,6 +4004,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -3235,6 +4033,8 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
+  globalyzer@0.1.0: {}
+
   globby@11.1.0:
     dependencies:
       array-union: 2.1.0
@@ -3243,6 +4043,8 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  globrex@0.1.2: {}
 
   graceful-fs@4.2.11: {}
 
@@ -3253,6 +4055,13 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -3269,6 +4078,12 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-in-the-middle@3.3.3:
+    dependencies:
+      cjs-module-lexer: 2.2.1
+      es-module-lexer: 2.3.2
+      module-details-from-path: 1.0.4
 
   import-meta-resolve@4.2.0: {}
 
@@ -3311,15 +4126,21 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-tokens@4.0.0: {}
+
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
+
+  jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
 
   kareem@2.6.3: {}
 
@@ -3397,6 +4218,10 @@ snapshots:
 
   lru-cache@11.5.2: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -3406,6 +4231,8 @@ snapshots:
   memory-pager@1.5.0: {}
 
   merge2@1.4.1: {}
+
+  meriyah@6.1.4: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -3422,6 +4249,8 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.18
 
+  minimist@1.2.8: {}
+
   minipass@7.1.3: {}
 
   minizlib@3.1.0:
@@ -3429,6 +4258,8 @@ snapshots:
       minipass: 7.1.3
 
   modern-screenshot@4.7.0: {}
+
+  module-details-from-path@1.0.4: {}
 
   mongodb-connection-string-url@3.0.2:
     dependencies:
@@ -3485,6 +4316,8 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-gyp-build@4.8.4: {}
+
+  node-releases@2.0.53: {}
 
   nopt@8.1.0:
     dependencies:
@@ -3603,11 +4436,22 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
+  progress@2.0.3: {}
+
+  proxy-from-env@1.1.0: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
   readdirp@4.1.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resolve-from@4.0.0: {}
 
@@ -3661,20 +4505,24 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.35.1(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3):
+  runed@0.35.1(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3):
     dependencies:
       dequal: 2.0.3
       esm-env: 1.2.2
       lz-string: 1.5.0
       svelte: 5.56.3
     optionalDependencies:
-      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
 
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
 
   safer-buffer@2.1.2: {}
+
+  semifies@1.0.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.8.4: {}
 
@@ -3698,7 +4546,15 @@ snapshots:
 
   slash@3.0.0: {}
 
+  sorcery@1.0.0:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      minimist: 1.2.8
+      tiny-glob: 0.2.9
+
   source-map-js@1.2.1: {}
+
+  source-map@0.6.1: {}
 
   sparse-bitfield@3.0.3:
     dependencies:
@@ -3747,10 +4603,10 @@ snapshots:
     optionalDependencies:
       svelte: 5.56.3
 
-  svelte-toolbelt@0.10.6(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3):
+  svelte-toolbelt@0.10.6(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3):
     dependencies:
       clsx: 2.1.1
-      runed: 0.35.1(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)
+      runed: 0.35.1(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)(typescript@5.9.3)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.56.3)
       style-to-object: 1.0.14
       svelte: 5.56.3
     transitivePeerDependencies:
@@ -3804,6 +4660,11 @@ snapshots:
 
   theme-change@2.5.2: {}
 
+  tiny-glob@0.2.9:
+    dependencies:
+      globalyzer: 0.1.0
+      globrex: 0.1.2
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -3848,6 +4709,12 @@ snapshots:
 
   undici-types@7.10.0: {}
 
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
+    dependencies:
+      browserslist: 4.28.8
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -3876,7 +4743,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
-  vitest@4.1.9(@types/node@24.3.0)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -3899,6 +4766,7 @@ snapshots:
       vite: 7.3.6(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.3.0
     transitivePeerDependencies:
       - msw
@@ -3933,6 +4801,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.1: {}
+
+  yallist@3.1.1: {}
 
   yallist@5.0.0: {}
 

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,1 +1,25 @@
-// Error handling can be added here if needed
+import * as Sentry from '@sentry/sveltekit';
+import { env } from '$env/dynamic/public';
+import { sharedSentryOptions } from '$lib/sentry';
+
+// Opt-in: no DSN, no SDK. Keeps forks, CI and local dev from reporting into
+// someone else's project, and makes "is Sentry on?" a deploy-time decision
+// rather than something baked into the bundle.
+const dsn = env.PUBLIC_SENTRY_DSN;
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    ...sharedSentryOptions,
+
+    // No `replayIntegration()`, and it must stay that way. Session Replay
+    // records the DOM, and by the time a message is on screen in /li/[room] it
+    // has been decrypted — enabling replay would hand Sentry the plaintext
+    // that this app goes to considerable trouble never to send anywhere. Same
+    // reasoning retires DOM breadcrumbs, which describe the element a user
+    // clicked and would be collected from inside message bubbles.
+    integrations: [Sentry.breadcrumbsIntegration({ dom: false })]
+  });
+}
+
+export const handleError = Sentry.handleErrorWithSentry();

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,7 +1,19 @@
+import * as Sentry from '@sentry/sveltekit';
 import { dbConnect } from '$lib/db';
 import { json, type Handle } from '@sveltejs/kit';
+import { sequence } from '@sveltejs/kit/hooks';
 import { env } from '$env/dynamic/private';
+import { env as publicEnv } from '$env/dynamic/public';
 import { RateLimiter } from '$lib/server/rateLimit';
+import { sharedSentryOptions } from '$lib/sentry';
+
+// Same opt-in as the client, and the same DSN — it's a public ingest key.
+if (publicEnv.PUBLIC_SENTRY_DSN) {
+  Sentry.init({
+    dsn: publicEnv.PUBLIC_SENTRY_DSN,
+    ...sharedSentryOptions
+  });
+}
 
 dbConnect();
 
@@ -76,7 +88,7 @@ function ruleFor(method: string, pathname: string): Rule | null {
   return null;
 }
 
-export const handle: Handle = async ({ event, resolve }) => {
+const appHandle: Handle = async ({ event, resolve }) => {
   const isApi = event.url.pathname.startsWith('/api/');
   const cors = isApi ? allowedOrigin(event.request.headers.get('origin')) : null;
 
@@ -120,3 +132,10 @@ export const handle: Handle = async ({ event, resolve }) => {
   }
   return response;
 };
+
+// Sentry first so a request that the app handler rejects (429, CORS preflight)
+// still gets traced, and so errors thrown further down are attributed to a
+// request rather than to nothing.
+export const handle: Handle = sequence(Sentry.sentryHandle(), appHandle);
+
+export const handleError = Sentry.handleErrorWithSentry();

--- a/src/lib/sentry.test.ts
+++ b/src/lib/sentry.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { scrubString, scrubEvent, PGP_PLACEHOLDER, RID_PLACEHOLDER } from './sentry';
+
+const ARMORED = `-----BEGIN PGP MESSAGE-----
+
+wV4DhP+cQz0eXYASAQdA5b9M0k7hR8kJ0hZ0Z0lm
+=abcd
+-----END PGP MESSAGE-----`;
+
+describe('scrubString', () => {
+  it('removes an armored PGP block', () => {
+    const out = scrubString(`readMessage failed on: ${ARMORED}`);
+    expect(out).not.toContain('BEGIN PGP');
+    expect(out).not.toContain('wV4DhP');
+    expect(out).toContain(PGP_PLACEHOLDER);
+  });
+
+  it('removes an armored private key block', () => {
+    const key =
+      '-----BEGIN PGP PRIVATE KEY BLOCK-----\n\nxYYEaoIT\n-----END PGP PRIVATE KEY BLOCK-----';
+    expect(scrubString(key)).toBe(PGP_PLACEHOLDER);
+  });
+
+  it('removes every block when several appear', () => {
+    const out = scrubString(`${ARMORED} and then ${ARMORED}`);
+    expect(out).not.toContain('BEGIN PGP');
+    expect(out.match(/\[pgp-block-redacted\]/g)).toHaveLength(2);
+  });
+
+  it('redacts the room id in an inbox url but keeps the route', () => {
+    expect(scrubString('https://sma.et/li/9WKgh__MaN6t')).toBe(
+      `https://sma.et/li/${RID_PLACEHOLDER}`
+    );
+  });
+
+  it('redacts the room id in a send url', () => {
+    expect(scrubString('https://sma.et/b/oDavRBo-wMOt?x=1')).toBe(
+      `https://sma.et/b/${RID_PLACEHOLDER}?x=1`
+    );
+  });
+
+  it('redacts rids passed as query params', () => {
+    expect(scrubString('/api/pgp?r=9WKgh__MaN6t&since=2026-08-17')).toBe(
+      `/api/pgp?r=${RID_PLACEHOLDER}&since=2026-08-17`
+    );
+  });
+
+  it('leaves the SvelteKit route pattern alone', () => {
+    // This is the transaction name; it identifies nobody and is what makes
+    // Sentry's grouping usable.
+    expect(scrubString('/li/[room]')).toBe('/li/[room]');
+  });
+
+  it('does not eat hashed asset filenames that merely sit under /b/', () => {
+    const asset = '/b/abcdefghijkl.js';
+    expect(scrubString(asset)).toBe(asset);
+  });
+
+  it('leaves ordinary error text untouched', () => {
+    const msg = 'TypeError: Cannot read properties of undefined (reading "length")';
+    expect(scrubString(msg)).toBe(msg);
+  });
+});
+
+describe('scrubEvent', () => {
+  it('scrubs strings nested anywhere in the event', () => {
+    const event = {
+      message: `boom ${ARMORED}`,
+      request: { url: 'https://sma.et/li/9WKgh__MaN6t' },
+      exception: {
+        values: [{ type: 'Error', value: `decrypt failed: ${ARMORED}` }]
+      },
+      breadcrumbs: [
+        { message: 'navigated', data: { to: 'https://sma.et/b/oDavRBo-wMOt' } },
+        { message: 'fetch', data: { url: '/api/pgp?r=9WKgh__MaN6t' } }
+      ],
+      extra: { deep: { deeper: { url: 'https://sma.et/li/9WKgh__MaN6t' } } }
+    };
+
+    const out = scrubEvent(event);
+    const asText = JSON.stringify(out);
+
+    expect(asText).not.toContain('BEGIN PGP');
+    expect(asText).not.toContain('9WKgh__MaN6t');
+    expect(asText).not.toContain('oDavRBo-wMOt');
+    // ...while the structure and the useful parts survive.
+    expect(out.exception.values[0].type).toBe('Error');
+    expect(out.request.url).toBe(`https://sma.et/li/${RID_PLACEHOLDER}`);
+    expect(out.breadcrumbs).toHaveLength(2);
+  });
+
+  it('survives null, numbers and undefined without throwing', () => {
+    expect(scrubEvent({ a: null, b: 1, c: undefined, d: true })).toEqual({
+      a: null,
+      b: 1,
+      c: undefined,
+      d: true
+    });
+  });
+
+  it('terminates on a deeply nested object', () => {
+    let node: Record<string, unknown> = { url: '/li/9WKgh__MaN6t' };
+    for (let i = 0; i < 40; i++) node = { child: node };
+    expect(() => scrubEvent(node)).not.toThrow();
+  });
+});

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared Sentry scrubbing, applied identically on the client and the server.
+ *
+ * Error reporting is an awkward fit for this app: the entire point is that the
+ * server only ever holds ciphertext, so anything that ships browser state to a
+ * third party can undo the guarantee the product is built on. Two rules follow
+ * from that, and neither is optional:
+ *
+ * 1. Session Replay is never enabled. It records the DOM, and on /li/[room]
+ *    the DOM holds messages that have already been decrypted — it would send
+ *    Sentry the plaintext the server deliberately never sees. See hooks.client.
+ * 2. Everything that does get sent goes through `scrubEvent` first.
+ *
+ * What gets removed:
+ *
+ * - **PGP blocks.** openpgp.js quotes its input in error messages, so a failed
+ *   `readMessage`/`decrypt` can carry an armored block — ciphertext, or worse,
+ *   a private key — straight into the exception text.
+ * - **Room ids.** An rid is the share link. It is not a secret, but it is the
+ *   name of a room, and a URL is attached to every event: left alone, Sentry
+ *   would accumulate a browsable index of who has a room and when they read
+ *   it. Route *patterns* (`/li/[room]`) are kept — they're what makes the
+ *   grouping useful and they name nobody.
+ */
+
+const PGP_BLOCK = /-----BEGIN PGP[\s\S]*?-----END PGP[^-]*-----/g;
+
+// An rid is exactly 12 base64url chars (see utils/hashing.ts). Anchoring on
+// the length and on a following path/query boundary keeps this from eating
+// unrelated path segments such as hashed asset filenames.
+const RID_IN_PATH = /\/(li|b)\/[A-Za-z0-9_-]{12}(?=$|[/?#])/g;
+const RID_IN_QUERY = /\b(r|rid|p|id)=[A-Za-z0-9_-]{12,}/g;
+
+export const PGP_PLACEHOLDER = '[pgp-block-redacted]';
+export const RID_PLACEHOLDER = '[rid]';
+
+/** Strip armored PGP and room ids out of a single string. */
+export function scrubString(value: string): string {
+  return value
+    .replace(PGP_BLOCK, PGP_PLACEHOLDER)
+    .replace(RID_IN_PATH, (_m, route) => `/${route}/${RID_PLACEHOLDER}`)
+    .replace(RID_IN_QUERY, (_m, key) => `${key}=${RID_PLACEHOLDER}`);
+}
+
+/**
+ * Walk an arbitrary Sentry event and scrub every string in it.
+ *
+ * Deliberately a blanket walk rather than a list of known fields: the SDK adds
+ * new places for strings to hide (breadcrumbs, request data, span attributes,
+ * contexts) faster than a hand-maintained allowlist would keep up with, and
+ * the failure mode of missing one is leaking plaintext.
+ */
+export function scrubDeep<T>(value: T, depth = 0): T {
+  if (depth > 12) return value;
+  if (typeof value === 'string') return scrubString(value) as unknown as T;
+  if (Array.isArray(value)) return value.map((v) => scrubDeep(v, depth + 1)) as unknown as T;
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = scrubDeep(v, depth + 1);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}
+
+/** `beforeSend`/`beforeSendTransaction` hook. */
+export function scrubEvent<T>(event: T): T {
+  return scrubDeep(event);
+}
+
+/**
+ * Options shared by both runtimes. `sendDefaultPii` stays false so the SDK
+ * doesn't attach IPs or request bodies — a message body here is ciphertext the
+ * server is not supposed to be accumulating copies of.
+ */
+export const sharedSentryOptions = {
+  sendDefaultPii: false,
+  tracesSampleRate: 0.1,
+  beforeSend: scrubEvent,
+  beforeSendTransaction: scrubEvent
+};

--- a/src/lib/utils/hashing.test.ts
+++ b/src/lib/utils/hashing.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { webcrypto } from 'node:crypto';
+import { createShortHash } from './hashing';
+
+// hashing.ts reaches for `window.crypto.subtle` because it only ever runs in
+// the browser; give it one.
+beforeAll(() => {
+  if (typeof globalThis.window === 'undefined') {
+    (globalThis as unknown as { window: unknown }).window = { crypto: webcrypto };
+  }
+});
+
+// An rid is the identity's name: it is minted once by this function (utils/pgp.ts)
+// and re-derived later to unlock the inbox (/li/[room]). Both sides must agree
+// bit-for-bit forever, so these fixtures are pinned rather than round-tripped —
+// a round-trip test passes happily while both sides are wrong together.
+//
+// The fixtures deliberately cover base64 padding chars, because that is where a
+// duplicate copy of this function inside /li/[room]/+page.svelte had drifted: it
+// called `.replace('+', '-')` with a *string* pattern, which substitutes only the
+// first occurrence, so any hash carrying two or more `+`/`/` was re-derived
+// wrongly and its owner could never open their own inbox.
+describe('createShortHash', () => {
+  it('is 12 chars of base64url for a plain hash', async () => {
+    expect(await createShortHash('sma-fixture-0', 12)).toMatch(/^[A-Za-z0-9_-]{12}$/);
+  });
+
+  it('translates every "/" in the hash, not just the first', async () => {
+    // raw base64 head is "/dfwNpd/OFGT" — two slashes
+    expect(await createShortHash('sma-fixture-105', 12)).toBe('_dfwNpd_OFGT');
+  });
+
+  it('translates every "+" in the hash, not just the first', async () => {
+    // raw base64 head is "j2ug14++o2eR" — two pluses
+    expect(await createShortHash('sma-fixture-12', 12)).toBe('j2ug14--o2eR');
+  });
+
+  it('translates "+" and "/" appearing together', async () => {
+    // raw base64 head is "r6htWds/n+pg"
+    expect(await createShortHash('sma-fixture-14', 12)).toBe('r6htWds_n-pg');
+  });
+
+  it('never leaks a raw base64 char into an rid', async () => {
+    for (let i = 0; i < 400; i++) {
+      expect(await createShortHash(`sma-fixture-${i}`, 12)).toMatch(/^[A-Za-z0-9_-]{12}$/);
+    }
+  });
+
+  it('is stable across calls', async () => {
+    const a = await createShortHash('sma-fixture-105', 12);
+    const b = await createShortHash('sma-fixture-105', 12);
+    expect(a).toBe(b);
+  });
+});

--- a/src/routes/li/[room]/+page.svelte
+++ b/src/routes/li/[room]/+page.svelte
@@ -4,6 +4,7 @@
   import * as openpgp from 'openpgp';
   import { PUBLIC_PGP_PASSPHRASE } from '$env/static/public';
   import { getAllFromLS, getLoadedPairFromLS } from '$lib/utils/localStorage';
+  import { createShortHash } from '$lib/utils/hashing';
   import { apiUrl, wsUrl } from '$lib/api';
   import { signedFetch } from '$lib/utils/signedRequest';
 
@@ -278,22 +279,17 @@
   let previousMessageCount = 0;
   let playSound = $state(false);
 
-  async function createShortHash(input: string, length: number): Promise<string> {
-    const encoder = new TextEncoder();
-    const data = encoder.encode(input);
-    const hash = await window.crypto.subtle.digest('SHA-256', data);
-    const hashString = btoa(String.fromCharCode(...new Uint8Array(hash)));
-
-    const base64url = hashString.replace('+', '-').replace('/', '_').replace(/=+$/, '');
-    return base64url.substring(0, length);
-  }
-
+  // Must be the *same* hash the identity was registered under (see
+  // utils/pgp.ts), not a re-implementation. A local copy used to live here and
+  // had drifted: it passed plain strings to `.replace`, which swaps only the
+  // first match, so a hash containing two or more `+`/`/` came back with the
+  // second one untranslated. ~2.7% of identities hash that way, and every one
+  // of them was permanently locked out of its own inbox — `unlocked` stayed
+  // false, so the page rendered its header over an empty void.
   const CheckIfUnlockable = async () => {
     if (!loadedPair) return false;
-    console.log(' checking unlock ');
 
     const hash = await createShortHash(loadedPair.prKey + loadedPair.pbKey, 12);
-    console.log('hash', hash, loadedPair.uniqueString);
     return hash === rid && loadedPair.uniqueString === rid;
   };
 

--- a/src/routes/li/[room]/Header/CopyLink.svelte
+++ b/src/routes/li/[room]/Header/CopyLink.svelte
@@ -17,8 +17,10 @@
   }
 </script>
 
-<Button onclick={copyLink} class="h-auto p-0">
-  <span class="p-4">
+<!-- Fills the leftover width in the phone-width button row; in the desktop
+     column it is stretched to the column's width instead. -->
+<Button onclick={copyLink} aria-label="Copy room link" class="h-auto flex-1 p-0 sm:flex-none">
+  <span class="flex items-center justify-center p-4">
     {#if copied}
       <span in:scale={{ start: 0.9 }} class="flex items-center justify-center gap-2">
         <span>

--- a/src/routes/li/[room]/ListenerHeader.svelte
+++ b/src/routes/li/[room]/ListenerHeader.svelte
@@ -24,7 +24,9 @@
 </script>
 
 {#if roomTitle && loadedPair && rid}
-  <div class="flex w-full flex-row gap-2 border p-1 pb-1">
+  <!-- Side by side once there's room for it; stacked on a phone, where the
+       button column was taking nearly half the width away from the title. -->
+  <div class="flex w-full min-w-0 flex-col gap-2 border p-1 pb-1 sm:flex-row">
     <ListenerHeaderTitle
       bind:roomTitle
       bind:pollingInterval

--- a/src/routes/li/[room]/ListenerHeaderConfig.svelte
+++ b/src/routes/li/[room]/ListenerHeaderConfig.svelte
@@ -14,9 +14,10 @@
   } = $props();
 </script>
 
-<span class="flex flex-col gap-2">
+<!-- A row under the title on a phone, the column beside it everywhere else. -->
+<span class="flex shrink-0 flex-row gap-2 sm:flex-col">
   <CopyLink />
-  <span class="flex flex-row gap-2">
+  <span class="flex shrink-0 flex-row gap-2">
     <SettingsModal
       {unpack}
       bind:pollingInterval

--- a/src/routes/li/[room]/ListenerHeaderTitle.svelte
+++ b/src/routes/li/[room]/ListenerHeaderTitle.svelte
@@ -58,8 +58,8 @@
     });
     const respTitle = await responseTitle.json();
 
-    if (respTitle.error || respTitle.status === 404) {
-      console.error(respTitle.message);
+    if (respTitle.status !== 200) {
+      console.error('Failed to fetch room title:', respTitle.body);
     } else {
       roomTitle = respTitle.body.title?.length == 0 ? respTitle.body.rid : respTitle.body.title;
     }
@@ -71,8 +71,8 @@
         title: roomTitle
       });
 
-      if (respUpdateTitle.error || respUpdateTitle.status >= 400) {
-        console.error(respUpdateTitle.body ?? respUpdateTitle.message);
+      if (respUpdateTitle.status !== 200) {
+        console.error('Failed to update room title:', respUpdateTitle.body);
       } else {
         roomTitle = respUpdateTitle.body.title;
       }
@@ -86,17 +86,54 @@
   });
 </script>
 
+<!--
+  Three stacked rows — nav, title, status — in normal flow.
+
+  They used to be absolutely positioned into the corners of this box, which
+  only held together because the box is stretched tall by the button column
+  beside it and is wide enough on a desktop for the rows never to meet. At
+  phone widths they overlapped: the nav buttons sat on top of the "Room"
+  heading, the status chips sat on top of the title, and `overflow-clip` took
+  a bite out of whichever chip reached the right edge. Laying them out as
+  actual rows costs nothing on a wide screen (justify-between reproduces the
+  same spread) and simply reflows on a narrow one, so keep it that way.
+-->
 <div
-  class="border-primary relative flex w-full flex-row items-center justify-start gap-2 overflow-clip border px-4"
+  class="border-primary relative flex w-full min-w-0 flex-col justify-between gap-2 border px-2 py-1 md:px-4"
 >
-  <div class=" flex flex-col md:flex-row md:items-center md:gap-2">
+  <div class="flex flex-row items-center gap-1">
+    <button
+      onclick={() => {
+        goto('/');
+      }}
+      in:fly={{ y: -4, duration: 400, easing: quintInOut }}
+      out:fly={{ y: 4, easing: quintInOut }}
+      aria-label="Home"
+      class="bg-secondary hover:bg-secondary/80 text-secondary-foreground flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-sm px-1 py-0.5 text-sm transition-all"
+    >
+      <House size={24} weight="duotone" />
+    </button>
+    <button
+      onclick={() => {
+        goto('/i');
+      }}
+      in:fly={{ y: -4, duration: 400, easing: quintInOut }}
+      out:fly={{ y: 4, easing: quintInOut }}
+      class="bg-primary hover:bg-primary/80 text-primary-foreground flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-sm px-2 py-0.5 text-sm transition-all"
+    >
+      <ArrowSquareUpLeft size={24} weight="duotone" />
+      <span> New Room </span>
+    </button>
+  </div>
+
+  <div class="flex min-w-0 flex-col gap-1 md:flex-row md:items-center md:gap-2">
     <h1 class="text-md font-semibold md:text-xl">Room</h1>
-    <div class="flex h-8 flex-row">
+    <div class="flex min-w-0 flex-row items-stretch">
       {#if isEditingTitle}
-        <span in:fly={{ x: -30 }} class="h-full">
+        <span in:fly={{ x: -30 }} class="min-w-0 flex-1">
           <Input
             bind:value={roomTitle}
-            class="h-full"
+            class="h-full w-full"
             type="text"
             minlength={1}
             maxlength={24}
@@ -107,13 +144,11 @@
                 toggleEditTitle();
               }
             }}
-            size={roomTitle.length > 5 ? roomTitle.length : 5}
-            style={`font-size: ${Math.ceil(roomTitle.length / 50)}em`}
           />
         </span>
-        <span in:fly={{ x: -90 }} class="flex h-full gap-0">
+        <span in:fly={{ x: -90 }} class="flex shrink-0 gap-0">
           <Button
-            class=" h-full "
+            class="h-full"
             variant="secondary"
             onclick={() => {
               if (roomTitle.length <= 0) return;
@@ -128,14 +163,21 @@
           </Button>
         </span>
       {:else}
+        <!-- A title can be 24 chars and the box can be 340px wide, so it has
+             to be allowed to wrap rather than run out of its own background. -->
         <span
           in:fly={{ x: 30 }}
-          class="bg-primary text-primary-foreground flex h-full items-center justify-center px-2 py-0.5 font-light"
+          class="bg-primary text-primary-foreground flex min-w-0 items-center justify-center px-2 py-1 font-light break-all"
         >
           {roomTitle}
         </span>
-        <span in:fly={{ x: 60 }}>
-          <Button variant="secondary" onclick={toggleEditTitle} class="btn btn-sm h-full ">
+        <span in:fly={{ x: 60 }} class="shrink-0">
+          <Button
+            variant="secondary"
+            onclick={toggleEditTitle}
+            aria-label="Rename room"
+            class="btn btn-sm h-full"
+          >
             <PencilSimpleLine size="24" weight="duotone" />
           </Button>
         </span>
@@ -143,31 +185,10 @@
     </div>
   </div>
 
-  <button
-    onclick={() => {
-      goto('/');
-    }}
-    in:fly={{ y: -4, duration: 400, easing: quintInOut }}
-    out:fly={{ y: 4, easing: quintInOut }}
-    class="bg-secondary hover:bg-secondary/80 text-secondary-foreground absolute top-0 left-0 flex cursor-pointer items-center justify-center gap-2 rounded-sm px-1 py-0.5 text-sm transition-all"
-  >
-    <House size={24} weight="duotone" />
-  </button>
-  <button
-    onclick={() => {
-      goto('/i');
-    }}
-    in:fly={{ y: -4, duration: 400, easing: quintInOut }}
-    out:fly={{ y: 4, easing: quintInOut }}
-    class="bg-primary hover:bg-primary/80 text-primary-foreground absolute top-0 left-8 flex cursor-pointer items-center justify-center gap-2 rounded-sm px-2 py-0.5 text-sm transition-all"
-  >
-    <ArrowSquareUpLeft size={24} weight="duotone" />
-    <span> New Room </span>
-  </button>
   <span
     in:fly={{ y: -4, duration: 400, easing: quintInOut }}
     out:fly={{ y: 4, easing: quintInOut }}
-    class="text-primary-foreground absolute bottom-1 left-0 flex gap-1"
+    class="text-primary-foreground flex flex-wrap items-center gap-1"
   >
     {#if wsConnected}
       <span
@@ -177,28 +198,36 @@
       </span>
     {:else}
       <span
-        class="bg-primary flex items-center justify-center gap-1 rounded-sm px-2 py-0.5 text-xs"
+        class="bg-primary flex items-center justify-center gap-1 rounded-sm px-2 py-0.5 text-xs whitespace-nowrap"
         title="Polling — WebSocket not connected"
         ><ClockCountdown /> {pollingInterval} s
       </span>
     {/if}
-    <span class="bg-primary flex items-center justify-center gap-1 rounded-sm px-2 py-0.5 text-xs"
-      ><WebhooksLogo /> {webhookUrl}
-    </span>
-    <span class="bg-primary rounded-sm px-2 py-0.5 text-xs"
+    <!-- Rendered only when one is actually set; an empty chip was just a
+         floating icon with nothing after it. -->
+    {#if webhookUrl}
+      <span
+        class="bg-primary flex max-w-full items-center justify-center gap-1 rounded-sm px-2 py-0.5 text-xs"
+        title={webhookUrl}
+        ><WebhooksLogo class="shrink-0" /> <span class="truncate">{webhookUrl}</span>
+      </span>
+    {/if}
+    <span class="bg-primary rounded-sm px-2 py-0.5 text-xs whitespace-nowrap"
       >{profanityEnabled ? 'Profanity Allowed' : 'Profanity Filter on'}</span
     >
-  </span>
-  {#key pollingInterval}
     {#if unpacking}
       <span
         in:fly={{ y: -4, duration: 400, easing: quintInOut, opacity: 1 }}
         out:fly={{ y: 4, easing: quintInOut, opacity: 1 }}
-        class="bg-primary text-primary-foreground absolute right-0 bottom-0 rounded-sm px-2 py-0.5 text-sm"
+        class="bg-primary text-primary-foreground rounded-sm px-2 py-0.5 text-xs whitespace-nowrap"
       >
         Loading ...
       </span>
-    {:else if !wsConnected}
+    {/if}
+  </span>
+
+  {#key pollingInterval}
+    {#if !unpacking && !wsConnected}
       <!-- The sweeping bar tracks the poll interval; meaningless once the
            socket is live and there is no timer, so only show it when polling. -->
       <span

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { sentrySvelteKit } from '@sentry/sveltekit';
 import { sveltekit } from '@sveltejs/kit/vite';
 import raw from 'vite-raw-plugin';
 import { WebSocketServer } from 'ws';
@@ -46,6 +47,26 @@ export default defineConfig({
     }
   },
   plugins: [
+    // Only the release build that can actually upload source maps loads this.
+    // Without a token the plugin does nothing useful — it says as much — while
+    // still dragging Babel into the module graph, which buries every `pnpm
+    // build` and `pnpm test` under a screen of @babel circular-dependency
+    // warnings. Error capture itself lives in the hooks and does not depend on
+    // this plugin, so gating it costs nothing locally.
+    ...(process.env.SENTRY_AUTH_TOKEN
+      ? [
+          sentrySvelteKit({
+            // The build plugin reports its own usage stats to Sentry by
+            // default. Opt out — nothing else here sends telemetry.
+            telemetry: false,
+            sourceMapsUploadOptions: {
+              org: 'robi-codes',
+              project: 'sma',
+              telemetry: false
+            }
+          })
+        ]
+      : []),
     raw({
       fileRegex: /\.md$/
     }),


### PR DESCRIPTION
Three things from the two screenshots on `sma.et`.

## 1. The blank inbox — `9WKgh__MaN6t` could never unlock

`/li/[room]` carried a **second copy** of `createShortHash` that had drifted from the real one in `src/lib/utils/hashing.ts`:

| where | code |
|---|---|
| `utils/hashing.ts` (mints the rid) | `.replace(/\+/g,'-').replace(/\//g,'_')` |
| `/li/[room]/+page.svelte` (re-derives it to unlock) | `.replace('+','-').replace('/','_')` |

A **string** pattern replaces only the first match. So any hash carrying two or more `+`/`/` was re-derived wrong, `hash === rid` failed, and `unlocked` stayed false. Everything below the header lives behind `{#if unlocked}` — including the "no messages yet" empty state — so the page rendered a header above nothing, with no error anywhere.

Measured over 20k identities: **2.73% are affected and were permanently locked out of their own inbox.** The reported room re-derived as `9WKgh_/MaN6t`. (The second screenshot's `oDavRBo-wMOt` has one `-`, which is why that one worked.)

Reproduced end-to-end against unmodified `master` with a same-shaped identity `35xWmzqaR_O_`:

```
checking unlock
hash 35xWmzqaR_O/ 35xWmzqaR_O_    <- computed vs stored: mismatch
ONMOUNT: false                     <- blank page
```

…and on this branch the same identity unlocks and renders.

Affected identities recover on load — their stored `uniqueString` and their `Listener` row were always written by the correct helper, so only the check was wrong. **No migration, no data touched.**

`src/lib/utils/hashing.test.ts` pins output against fixtures with two `/`, two `+`, and one of each. Pinned rather than round-tripped: a round-trip passes happily while both sides are wrong together. Confirmed the tests fail against the old implementation.

## 2. The mangled mobile header

The header positioned its nav buttons and status chips with `absolute` into the corners of a box that is only tall enough because the button column beside it stretches it. At 390px they collided: nav buttons over the "Room" heading, chips over the title, and `overflow-clip` slicing whichever chip hit the right edge — hence "Profanit / Allowed".

Now laid out as three rows in normal flow. `justify-between` reproduces the same spread when wide, so **desktop is unchanged**; it just reflows when narrow. The button column becomes a row under the title on a phone. Titles wrap instead of overrunning their pill, and the webhook chip only renders when a webhook is set.

Verified at 390px and 1280px — default, mid-rename, and with a max-length 24-char title — asserting nothing overflows the viewport and nothing is clipped by an ancestor.

## 3. Sentry, back but muzzled

`@sentry/sveltekit` in both hooks, gated on `PUBLIC_SENTRY_DSN` (no DSN → no SDK, the default locally and in CI).

Error reporting is an awkward fit for an app whose premise is that plaintext never leaves the browser, so two constraints in `src/lib/sentry.ts` are load-bearing:

- **No Session Replay, DOM breadcrumbs off.** Replay records the DOM, and by the time a message is on screen in `/li/[room]` it has been *decrypted*. Enabling it would ship Sentry exactly the plaintext the server is built never to receive.
- **`scrubEvent` on `beforeSend`.** Strips armored PGP blocks (openpgp.js quotes its input, so a failed `decrypt` can drag ciphertext — or a private key — into the exception text) and redacts rids from paths and query strings, while keeping route patterns like `/li/[room]`, which name nobody and are what makes grouping useful.

The Vite plugin is gated on `SENTRY_AUTH_TOKEN`: without one it can't upload source maps anyway, and it drags Babel in, burying every build under ~25 lines of circular-dependency warnings.

**Being straight about the limit: Sentry would not have caught bug #1.** Nothing threw — it returned `false` and rendered an empty page. Silent-wrong-answer bugs need tests or an explicit failure state, not instrumentation.

## Before you merge

- [ ] Set `PUBLIC_SENTRY_DSN` in the box's env — the historical DSN is in `875833f`, and a DSN is a public write-only key. Nothing is reported until you do.
- [ ] Optionally set `SENTRY_AUTH_TOKEN` in whatever builds production, for de-minified stack traces.

## Checks

- `pnpm test:unit` — 86 passed (9 files), 21 of them new
- `pnpm check` — 1 error / 4 warnings, **byte-identical to `master`** (pre-existing `lg:flex-row` in `PGPPowerUser.svelte`)
- `pnpm build` — exit 0, and now 0 circular-dependency warnings
- `eslint` on touched files — 8 problems, identical to `master`; all on pre-existing lines
- `pnpm lint` is broken on `master` too (prettier's Svelte plugin throws `getVisitorKeys is not a function` on all 48 `.svelte` files) — untouched here, but it's worth its own fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
